### PR TITLE
Improve color blending of text gradients by interpolating in CIE space

### DIFF
--- a/src/main/java/com/akoot/plugins/ultravanilla/reference/Palette.java
+++ b/src/main/java/com/akoot/plugins/ultravanilla/reference/Palette.java
@@ -3,6 +3,7 @@ package com.akoot.plugins.ultravanilla.reference;
 import net.md_5.bungee.api.ChatColor;
 
 import java.awt.*;
+import java.awt.color.ColorSpace;
 import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -84,15 +85,28 @@ public class Palette {
         return gradient(str, LegacyColors.getColor(color1), LegacyColors.getColor(color2));
     }
 
-    public static String gradient(String str, Color one, Color two) {
-        int l = str.length();
+    // implementation by lordpipe
+    public static String gradient(String str, Color from, Color to) {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < l; i++) {
-            sb.append(ChatColor.of(new Color(
-                    (one.getRed() + (i * (1.0F / l) * (two.getRed() - one.getRed()))) / 255,
-                    (one.getGreen() + (i * (1.0F / l) * (two.getGreen() - one.getGreen()))) / 255,
-                    (one.getBlue() + (i * (1.0F / l) * (two.getBlue() - one.getBlue()))) / 255
-            )));
+
+        ColorSpace cie = ColorSpace.getInstance(ColorSpace.CS_CIEXYZ);
+        ColorSpace srgb = ColorSpace.getInstance(ColorSpace.CS_sRGB);
+
+        float[] cieFrom = cie.fromRGB(from.getRGBColorComponents(null));
+        float[] cieTo = cie.fromRGB(to.getRGBColorComponents(null));
+
+        for (int i = 0, l = str.length(); i < l; i++) {
+            // do interpolation in CIE space
+            float[] interpolatedCie = new float[] {
+                    cieFrom[0] + (i * (1.0F / l)) * (cieTo[0] - cieFrom[0]),
+                    cieFrom[1] + (i * (1.0F / l)) * (cieTo[1] - cieFrom[1]),
+                    cieFrom[2] + (i * (1.0F / l)) * (cieTo[2] - cieFrom[2])
+            };
+
+            // we could just pass the CIE value directly into `new Color`, but it seems the ChatColor API expects the
+            // conversion to sRGB to be pre-computed, so it fails
+            float[] interpolatedSrgb = srgb.fromCIEXYZ(interpolatedCie);
+            sb.append(ChatColor.of(new Color(interpolatedSrgb[0], interpolatedSrgb[1], interpolatedSrgb[2])));
             sb.append(str.charAt(i));
         }
         return sb.toString();


### PR DESCRIPTION
Background
---

When computers represent colors, they make use of sRGB space, a gamma-encoded value that allows for higher resolution of darker values <sup>[1]</sup> <sup>[2]</sup>. The purpose of sRGB is to prioritize human visual perception, which follows a power law relationship &mdash; the less stimuli there is, the greater any slight differences are percieved compared to a corresponding change with a strong stimuli

![2020-07-17-042326_730x266_escrotum](https://user-images.githubusercontent.com/68424788/87781854-b0c3fe80-c7ee-11ea-94b5-424dcdaed532.png)

However, when processing color data, these sRGB values must be converted into a linear space in order to be correctly manipulated. Doing a basic interpolation on sRGB values can result in gradients being too dark or getting muddied by incorrect colors.

One solution is to work in the gamma-decoded linear version of sRGB <sup>[3]</sup>. This improves blending significantly and just requires a piecewise function, one part linear and the other part a power function.

![2020-07-17-043539_638x513_escrotum](https://user-images.githubusercontent.com/68424788/87781868-b4f01c00-c7ee-11ea-8c59-d3f6df39690c.png)

---

The Java standard library actually gives us a much better solution though - do the interpolation in CIE XYZ space, a color space designed to match human perceptual differences along any euclidean distance within it as represented in a 3D space. This allows for gradients, alpha blending, image scaling, and antialiasing with a correct interpolation of luminosity, chroma, and hue. It should be used for most non-realtime color processing and manipulation purposes.

I've implemented this and it gives much better results &mdash; significantly improving readability for most of the examples

Before

![hn4uEQU](https://user-images.githubusercontent.com/68424788/87781767-8eca7c00-c7ee-11ea-9954-1aa78b2e4600.png)

After

![6ME0Wo2](https://user-images.githubusercontent.com/68424788/87781787-9853e400-c7ee-11ea-882c-ea3442362e27.png)

One thing I wasn't sure about with this PR was the purpose of the `RawUtil` class - is this just helper functions for future use? I've implemented the gradient function in both `Palette` and `RawUtil` but the `RawUtil` implementation never actually gets used it seems.

Further work could add a separate color formatting command to work in CIE LCH mode with H going either counterclockwise or clockwise, allowing for hue-aware gradients to give much better rainbow generation results than the current `&x` mode.

---

References

<sup>[1]:</sup> https://www.youtube.com/watch?v=LKnqECcg6Gw
<sup>[2]:</sup> https://blog.johnnovak.net/2016/09/21/what-every-coder-should-know-about-gamma/
<sup>[3]:</sup> https://en.wikipedia.org/wiki/SRGB#The_sRGB_transfer_function_(%22gamma%22)

---

I release my contributions under [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/), so you can use it perpetually for any purpose, sublicense, remove attribution, etc.