### PR TITLE
Implement new `/promote` command

### DIFF
--- a/src/main/java/com/akoot/plugins/ultravanilla/UltraVanilla.java
+++ b/src/main/java/com/akoot/plugins/ultravanilla/UltraVanilla.java
@@ -334,6 +334,7 @@ public final class UltraVanilla extends JavaPlugin {
         SignCommand signCommand = new SignCommand(instance);
         getCommand("sign").setExecutor(signCommand);
         getServer().getPluginManager().registerEvents(signCommand, instance);
+        getCommand("promote").setExecutor(new PromoteCommand(instance));
 
     }
 

--- a/src/main/java/com/akoot/plugins/ultravanilla/commands/PromoteCommand.java
+++ b/src/main/java/com/akoot/plugins/ultravanilla/commands/PromoteCommand.java
@@ -1,0 +1,70 @@
+
+package com.akoot.plugins.ultravanilla.commands;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import com.akoot.plugins.ultravanilla.UltraVanilla;
+
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabExecutor;
+
+import org.bukkit.entity.Player;
+
+import net.md_5.bungee.api.ChatColor;
+import net.milkbowl.vault.permission.Permission;
+
+public class PromoteCommand extends UltraCommand implements TabExecutor {
+    public static final ChatColor COLOR = ChatColor.GREEN;
+    private Permission permissions;
+
+    public PromoteCommand(UltraVanilla instance) {
+        super(instance);
+        this.color = COLOR;
+        permissions = instance.getPermissions();
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        for (String playerName : args) {
+            String demoteFrom = "default";
+            String promoteTo = null;
+
+            Player player = Bukkit.getPlayer(playerName);
+
+            if (player != null && !plugin.hasRightRole(player)) {
+                ArrayList<String> roleOrder = new ArrayList<>(Arrays.asList(plugin.getAllTimedRoles()));
+                roleOrder.add(0, "default");
+
+                String existingRole = permissions.getPrimaryGroup(player);
+                int currentPos = roleOrder.indexOf(existingRole);
+
+                // prevents demoting staff and/or special roles
+                if (currentPos == -1) continue;
+
+                promoteTo = roleOrder.get(Math.min(currentPos + 1, roleOrder.size() - 1));
+
+                demoteFrom = existingRole;
+            }
+
+            if (promoteTo != null) {
+                sender.sendMessage(format(command, "format.promoted", "{player}", player.getName(), "{rank}", promoteTo));
+
+                permissions.playerRemoveGroup(player, demoteFrom);
+                permissions.playerAddGroup(player, promoteTo);
+            } else {
+                sender.sendMessage(format(command, "format.did-not-promote", "{player}", playerName));
+            }
+        }
+
+        return true;
+    }
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        return null;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -168,6 +168,10 @@ strings:
         seen:
           last: '$noun{player} $color was last seen on $object{date}'
           first: '$noun{player} $color was first seen on $object{date}'
+    promote:
+      format:
+        did-not-promote: 'Did not promote $noun{player}'
+        promoted: 'Promoted $noun{player} to $object{rank}'
     spawn:
       message:
         set: 'Spawn set to your location'

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -191,6 +191,12 @@ commands:
       /sign rewrite <line1>[|line2|line3|line4]
       /sign edit
       /sign clear
+  promote:
+    description: Promote player(s)
+    permission: ultravanilla.command.promote
+    usage: |
+      /promote player1
+      /promote player1 player2
 #  mail:
 #    description: Send mail to a player
 #    usage: |


### PR DESCRIPTION
LuckPerms does not allow access to `/lp user <user> promote <track>`
without giving giving permission to manage all LuckPerms things. This
patch provides a `/promote` command that directly accesses the Vault API
to do the promotion. This command also prevents over-promotion and
demotion of special roles.