### PR TITLE
Added OfflinePlayerCacheManager

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.51"
 name := "UltraVanilla"
 resolvers ++= List(
     "jitpack.io" at "https://jitpack.io",
-    "papermc" at "https://papermc.io/repo/repository/maven-public/",
+    "papermc" at "https://repo.papermc.io/repository/maven-public/",
     "dmulloy2-repo" at "https://repo.dmulloy2.net/nexus/repository/public/",
     "jcenter" at "https://jcenter.bintray.com",
     "m2-dv8tion" at "https://m2.dv8tion.net/releases",

--- a/src/main/java/world/ultravanilla/UltraVanilla.scala
+++ b/src/main/java/world/ultravanilla/UltraVanilla.scala
@@ -455,11 +455,10 @@ class UltraVanilla extends JavaPlugin {
     var autocompleteLastUpdated = new Date(0)
     
     def offlineAutocompleteList(): ArrayList[String] = {
-        val now = new Date()
-        if ((now.getTime - autocompleteLastUpdated.getTime) < 90 * 60 * 1000)
+        if ((new Date().getTime - autocompleteLastUpdated.getTime) < 90 * 60 * 1000)
             return cachedAutocompleteList
-    
-        autocompleteLastUpdated = now
+
+        autocompleteLastUpdated = new Date()
         cachedAutocompleteList.clear()
     
         val cache = offlinePlayerCacheManager.getOfflinePlayers()

--- a/src/main/java/world/ultravanilla/UltraVanilla.scala
+++ b/src/main/java/world/ultravanilla/UltraVanilla.scala
@@ -408,7 +408,7 @@ class UltraVanilla extends JavaPlugin {
 
     def saveStorage() = {
         saveConfig(storage, "storage.yml")
-        offlinePlayerCacheManager.saveCache();
+        offlinePlayerCacheManager.saveCache()
     }
 
     def saveConfig(config: YamlConfiguration, fileName: String) =

--- a/src/main/java/world/ultravanilla/UltraVanilla.scala
+++ b/src/main/java/world/ultravanilla/UltraVanilla.scala
@@ -313,6 +313,12 @@ class UltraVanilla extends JavaPlugin {
         keepinvOffTeam.setPrefix("KeepInventory OFF ")
         keepinvOffTeam.setOption(Team.Option.NAME_TAG_VISIBILITY, Team.OptionStatus.ALWAYS)
         keepinvOffTeam.setColor(bukkit.ChatColor.RED)
+
+        
+
+        offlinePlayerCacheManager.loadCache();
+
+
     }
 
     def setMOTD(motd: String) = this.motd = Palette.translate(motd)

--- a/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
+++ b/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
@@ -6,10 +6,15 @@ import world.ultravanilla.cache.data.PlayerCacheEntry;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.bukkit.OfflinePlayer;
 
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.Gson;
 
+import java.lang.reflect.Type;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -26,7 +31,7 @@ public class OfflinePlayerCacheManager {
 
     public OfflinePlayerCacheManager(UltraVanilla instance) {
         this.plugin = instance;
-        this.cacheFile = new File(plugin.getDataFolder(), "offline-players.ser");
+        this.cacheFile = new File(plugin.getDataFolder(), "offline-players.json");
     }
 
     public Object2ObjectOpenHashMap<UUID, PlayerCacheEntry> getOfflinePlayers() {
@@ -81,18 +86,21 @@ public class OfflinePlayerCacheManager {
     }
 
     public void saveCache() throws IOException {
-        try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(cacheFile))) {
-            oos.writeObject(playerCache);
+        Gson gson = new Gson();
+        try (FileWriter writer = new FileWriter(cacheFile)) {
+            gson.toJson(playerCache, writer);
         }
     }
 
-    private void loadCache() throws IOException, ClassNotFoundException {
+    public void loadCache() throws IOException {
         if (!cacheFile.exists()) return;
-        try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(cacheFile))) {
-            Object obj = ois.readObject();
-            if (obj instanceof Object2ObjectOpenHashMap) {
+        Gson gson = new Gson();
+        try (FileReader reader = new FileReader(cacheFile)) {
+            Type type = new TypeToken<Object2ObjectOpenHashMap<UUID, PlayerCacheEntry>>(){}.getType();
+            Object2ObjectOpenHashMap<UUID, PlayerCacheEntry> loaded = gson.fromJson(reader, type);
+            if (loaded != null) {
                 playerCache.clear();
-                playerCache.putAll((Object2ObjectOpenHashMap<UUID, PlayerCacheEntry>) obj);
+                playerCache.putAll(loaded);
             }
         }
     }

--- a/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
+++ b/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
@@ -3,7 +3,7 @@ package world.ultravanilla.cache;
 import world.ultravanilla.UltraVanilla;
 import world.ultravanilla.cache.data.PlayerCacheEntry;
 
-import org.bukkit.OfflinePlayer;
+import org.bukkit.Bukkit; // <-- Needed for Bukkit.isPrimaryThread() and Bukkit.getScheduler()
 
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.Gson;
@@ -16,6 +16,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.HashMap;
 
@@ -31,54 +33,57 @@ public class OfflinePlayerCacheManager {
     }
 
     public HashMap<UUID, PlayerCacheEntry> getOfflinePlayers() {
-        if (playerCache.isEmpty()) {
-            try {
-                loadCache();
-            } catch (Exception e) {
-                plugin.getLogger().log(Level.WARNING, "Failed to load offline player cache", e);
-            }
-        }
-        
-        lastLoaded = System.currentTimeMillis();
-        File playerDataFolder = new File(plugin.getServer().getWorlds().get(0).getWorldFolder(), "playerdata");
-        File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
-        if (files != null) {
-            for (File file : files) {
-                String fileName = file.getName();
-                String uuidPart = fileName.substring(0, fileName.length() - 4);
+        synchronized (playerCache) {
+            if (playerCache.isEmpty()) {
                 try {
-                    UUID uuid = UUID.fromString(uuidPart);
-                    long lastModified = file.lastModified();
-                    PlayerCacheEntry entry = playerCache.get(uuid);
-                    if (entry == null || entry.lastModified != lastModified) {
-                        String name = plugin.getServer().getOfflinePlayer(uuid).getName();
-                        playerCache.put(uuid, new PlayerCacheEntry(uuid, name, lastModified));
-                    }
-                } catch (IllegalArgumentException ignored) {
-                    // Ignore files that don't match UUID format
+                    loadCache();
+                } catch (Exception e) {
+                    plugin.getLogger().log(Level.WARNING, "Failed to load offline player cache", e);
                 }
             }
+            
+            lastLoaded = System.currentTimeMillis();
+            File playerDataFolder = new File(plugin.getServer().getWorlds().get(0).getWorldFolder(), "playerdata");
+            File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
+            if (files != null) {
+                for (File file : files) {
+                    String fileName = file.getName();
+                    String uuidPart = fileName.substring(0, fileName.length() - 4);
+                    try {
+                        UUID uuid = UUID.fromString(uuidPart);
+                        long lastModified = file.lastModified();
+                        PlayerCacheEntry entry = playerCache.get(uuid);
+                        if (entry == null || entry.lastModified != lastModified) {
+                            String name = getPlayerNameSync(uuid);
+                            playerCache.put(uuid, new PlayerCacheEntry(uuid, name, lastModified));
+                        }
+                    } catch (IllegalArgumentException ignored) {
+                        // Ignore files that don't match UUID format
+                    }
+                }
+            }
+            return new HashMap<>(playerCache);
         }
-    
-        return playerCache;
     }
 
     public List<UUID> getAllPlayerUUIDs() {
-        List<UUID> uuids = new ArrayList<>();
-        File playerDataFolder = new File(plugin.getServer().getWorlds().get(0).getWorldFolder(), "playerdata");
-        File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
-        if (files != null) {
-            for (File file : files) {
-                String name = file.getName();
-                String uuidPart = name.substring(0, name.length() - 4); // Remove ".dat"
-                try {
-                    uuids.add(UUID.fromString(uuidPart));
-                } catch (IllegalArgumentException ignored) {
-                    // Ignore files that don't match UUID format
+        synchronized (playerCache) {
+            List<UUID> uuids = new ArrayList<>();
+            File playerDataFolder = new File(plugin.getServer().getWorlds().get(0).getWorldFolder(), "playerdata");
+            File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
+            if (files != null) {
+                for (File file : files) {
+                    String name = file.getName();
+                    String uuidPart = name.substring(0, name.length() - 4); // Remove ".dat"
+                    try {
+                        uuids.add(UUID.fromString(uuidPart));
+                    } catch (IllegalArgumentException ignored) {
+                        // Ignore files that don't match UUID format
+                    }
                 }
             }
+            return uuids;
         }
-        return uuids;
     }
 
     public void saveCache() throws IOException {
@@ -93,12 +98,30 @@ public class OfflinePlayerCacheManager {
     public void loadCache() throws IOException {
         if (!cacheFile.exists()) return;
         Gson gson = new Gson();
-        try (FileReader reader = new FileReader(cacheFile)) {
-            Type type = new TypeToken<HashMap<UUID, PlayerCacheEntry>>(){}.getType();
-            HashMap<UUID, PlayerCacheEntry> loaded = gson.fromJson(reader, type);
-            if (loaded != null) {
-                playerCache.clear();
-                playerCache.putAll(loaded);
+        synchronized (playerCache) {
+            try (FileReader reader = new FileReader(cacheFile)) {
+                Type type = new TypeToken<HashMap<UUID, PlayerCacheEntry>>(){}.getType();
+                HashMap<UUID, PlayerCacheEntry> loaded = gson.fromJson(reader, type);
+                if (loaded != null) {
+                    playerCache.clear();
+                    playerCache.putAll(loaded);
+                }
+            }
+        }
+    }
+
+    private String getPlayerNameSync(UUID uuid) {
+        if (Bukkit.isPrimaryThread()) {
+            return plugin.getServer().getOfflinePlayer(uuid).getName();
+        } else {
+            try {
+                Future<String> future = Bukkit.getScheduler().callSyncMethod(plugin, () ->
+                    plugin.getServer().getOfflinePlayer(uuid).getName()
+                );
+                return future.get();
+            } catch (InterruptedException | ExecutionException e) {
+                plugin.getLogger().log(Level.WARNING, "Failed to fetch player name for " + uuid, e);
+                return null;
             }
         }
     }

--- a/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
+++ b/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
@@ -3,7 +3,7 @@ package world.ultravanilla.cache;
 import world.ultravanilla.UltraVanilla;
 import world.ultravanilla.cache.data.PlayerCacheEntry;
 
-import org.bukkit.Bukkit; // <-- Needed for Bukkit.isPrimaryThread() and Bukkit.getScheduler()
+import org.bukkit.Bukkit;
 
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.Gson;
@@ -72,23 +72,22 @@ public class OfflinePlayerCacheManager {
     }
 
     public List<UUID> getAllPlayerUUIDs() {
-        synchronized (playerCache) {
-            List<UUID> uuids = new ArrayList<>();
-            File playerDataFolder = new File(plugin.getServer().getWorlds().get(0).getWorldFolder(), "playerdata");
-            File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
-            if (files != null) {
-                for (File file : files) {
-                    String name = file.getName();
-                    String uuidPart = name.substring(0, name.length() - 4); // Remove ".dat"
-                    try {
-                        uuids.add(UUID.fromString(uuidPart));
-                    } catch (IllegalArgumentException ignored) {
-                        // Ignore files that don't match UUID format
-                    }
+        List<UUID> uuids = new ArrayList<>();
+        File playerDataFolder = new File(plugin.getServer().getWorlds().get(0).getWorldFolder(), "playerdata");
+        File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
+        if (files != null) {
+            for (File file : files) {
+                String name = file.getName();
+                String uuidPart = name.substring(0, name.length() - 4); // Remove ".dat"
+                try {
+                    uuids.add(UUID.fromString(uuidPart));
+                } catch (IllegalArgumentException ignored) {
+                    // Ignore files that don't match UUID format
                 }
             }
-            return uuids;
         }
+        return uuids;
+        
     }
 
     public void saveCache() throws IOException {
@@ -103,11 +102,11 @@ public class OfflinePlayerCacheManager {
     public void loadCache() throws IOException {
         if (!cacheFile.exists()) return;
         Gson gson = new Gson();
-        synchronized (playerCache) {
-            try (FileReader reader = new FileReader(cacheFile)) {
-                Type type = new TypeToken<HashMap<UUID, PlayerCacheEntry>>(){}.getType();
-                HashMap<UUID, PlayerCacheEntry> loaded = gson.fromJson(reader, type);
-                if (loaded != null) {
+        try (FileReader reader = new FileReader(cacheFile)) {
+            Type type = new TypeToken<HashMap<UUID, PlayerCacheEntry>>(){}.getType();
+            HashMap<UUID, PlayerCacheEntry> loaded = gson.fromJson(reader, type);
+            if (loaded != null) {
+                synchronized (playerCache) {
                     playerCache.clear();
                     playerCache.putAll(loaded);
                 }

--- a/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
+++ b/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
@@ -1,0 +1,99 @@
+package world.ultravanilla.cache;
+
+import world.ultravanilla.UltraVanilla;
+import world.ultravanilla.cache.data.PlayerCacheEntry;
+
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.bukkit.OfflinePlayer;
+
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Level;
+
+public class OfflinePlayerCacheManager {
+    private final UltraVanilla plugin;
+    private final Object2ObjectOpenHashMap<UUID, PlayerCacheEntry> playerCache = new Object2ObjectOpenHashMap<>();
+    private final File cacheFile;
+    private long lastLoaded = 0L;
+
+    public OfflinePlayerCacheManager(UltraVanilla instance) {
+        this.plugin = instance;
+        this.cacheFile = new File(plugin.getDataFolder(), "offline-players.ser");
+    }
+
+    public Object2ObjectOpenHashMap<UUID, PlayerCacheEntry> getOfflinePlayers() {
+        if (playerCache.isEmpty()) {
+            try {
+                loadCache();
+            } catch (Exception e) {
+                plugin.getLogger().log(Level.WARNING, "Failed to load offline player cache", e);
+            }
+        }
+        
+        lastLoaded = System.currentTimeMillis();
+        File playerDataFolder = new File(plugin.getServer().getWorlds().get(0).getWorldFolder(), "playerdata");
+        File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
+        if (files != null) {
+            for (File file : files) {
+                String fileName = file.getName();
+                String uuidPart = fileName.substring(0, fileName.length() - 4);
+                try {
+                    UUID uuid = UUID.fromString(uuidPart);
+                    long lastModified = file.lastModified();
+                    PlayerCacheEntry entry = playerCache.get(uuid);
+                    if (entry == null || entry.lastModified != lastModified) {
+                        String name = plugin.getServer().getOfflinePlayer(uuid).getName();
+                        playerCache.put(uuid, new PlayerCacheEntry(uuid, name, lastModified));
+                    }
+                } catch (IllegalArgumentException ignored) {
+                    // Ignore files that don't match UUID format
+                }
+            }
+        }
+    
+        return playerCache;
+    }
+
+    public List<UUID> getAllPlayerUUIDs() {
+        List<UUID> uuids = new ArrayList<>();
+        File playerDataFolder = new File(plugin.getServer().getWorlds().get(0).getWorldFolder(), "playerdata");
+        File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
+        if (files != null) {
+            for (File file : files) {
+                String name = file.getName();
+                String uuidPart = name.substring(0, name.length() - 4); // Remove ".dat"
+                try {
+                    uuids.add(UUID.fromString(uuidPart));
+                } catch (IllegalArgumentException ignored) {
+                    // Ignore files that don't match UUID format
+                }
+            }
+        }
+        return uuids;
+    }
+
+    public void saveCache() throws IOException {
+        try (ObjectOutputStream oos = new ObjectOutputStream(new FileOutputStream(cacheFile))) {
+            oos.writeObject(playerCache);
+        }
+    }
+
+    private void loadCache() throws IOException, ClassNotFoundException {
+        if (!cacheFile.exists()) return;
+        try (ObjectInputStream ois = new ObjectInputStream(new FileInputStream(cacheFile))) {
+            Object obj = ois.readObject();
+            if (obj instanceof Object2ObjectOpenHashMap) {
+                playerCache.clear();
+                playerCache.putAll((Object2ObjectOpenHashMap<UUID, PlayerCacheEntry>) obj);
+            }
+        }
+    }
+}

--- a/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
+++ b/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
@@ -55,7 +55,10 @@ public class OfflinePlayerCacheManager {
                         PlayerCacheEntry entry = playerCache.get(uuid);
                         if (entry == null || entry.lastModified != lastModified) {
                             String name = getPlayerNameSync(uuid);
-                            playerCache.put(uuid, new PlayerCacheEntry(uuid, name, lastModified));
+                            if (name != null) {
+                                playerCache.put(uuid, new PlayerCacheEntry(uuid, name, lastModified));
+                            }
+
                         }
                     } catch (IllegalArgumentException ignored) {
                         // Ignore files that don't match UUID format

--- a/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
+++ b/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
@@ -82,11 +82,13 @@ public class OfflinePlayerCacheManager {
     }
 
     public void saveCache() throws IOException {
-        Gson gson = new Gson();
-        try (FileWriter writer = new FileWriter(cacheFile)) {
-            gson.toJson(playerCache, writer);
+            Gson gson = new Gson();
+            synchronized (playerCache) {
+                try (FileWriter writer = new FileWriter(cacheFile)) {
+                    gson.toJson(new HashMap<>(playerCache), writer);
+                }
+            }
         }
-    }
 
     public void loadCache() throws IOException {
         if (!cacheFile.exists()) return;

--- a/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
+++ b/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
@@ -3,7 +3,6 @@ package world.ultravanilla.cache;
 import world.ultravanilla.UltraVanilla;
 import world.ultravanilla.cache.data.PlayerCacheEntry;
 
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import org.bukkit.OfflinePlayer;
 
 import com.google.gson.reflect.TypeToken;
@@ -11,21 +10,18 @@ import com.google.gson.Gson;
 
 import java.lang.reflect.Type;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.logging.Level;
+import java.util.HashMap;
 
 public class OfflinePlayerCacheManager {
     private final UltraVanilla plugin;
-    private final Object2ObjectOpenHashMap<UUID, PlayerCacheEntry> playerCache = new Object2ObjectOpenHashMap<>();
+    private final HashMap<UUID, PlayerCacheEntry> playerCache = new HashMap<>();
     private final File cacheFile;
     private long lastLoaded = 0L;
 
@@ -34,7 +30,7 @@ public class OfflinePlayerCacheManager {
         this.cacheFile = new File(plugin.getDataFolder(), "offline-players.json");
     }
 
-    public Object2ObjectOpenHashMap<UUID, PlayerCacheEntry> getOfflinePlayers() {
+    public HashMap<UUID, PlayerCacheEntry> getOfflinePlayers() {
         if (playerCache.isEmpty()) {
             try {
                 loadCache();
@@ -96,8 +92,8 @@ public class OfflinePlayerCacheManager {
         if (!cacheFile.exists()) return;
         Gson gson = new Gson();
         try (FileReader reader = new FileReader(cacheFile)) {
-            Type type = new TypeToken<Object2ObjectOpenHashMap<UUID, PlayerCacheEntry>>(){}.getType();
-            Object2ObjectOpenHashMap<UUID, PlayerCacheEntry> loaded = gson.fromJson(reader, type);
+            Type type = new TypeToken<HashMap<UUID, PlayerCacheEntry>>(){}.getType();
+            HashMap<UUID, PlayerCacheEntry> loaded = gson.fromJson(reader, type);
             if (loaded != null) {
                 playerCache.clear();
                 playerCache.putAll(loaded);

--- a/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
+++ b/src/main/java/world/ultravanilla/cache/OfflinePlayerCacheManager.java
@@ -44,24 +44,26 @@ public class OfflinePlayerCacheManager {
             
             lastLoaded = System.currentTimeMillis();
             File playerDataFolder = new File(plugin.getServer().getWorlds().get(0).getWorldFolder(), "playerdata");
-            File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
-            if (files != null) {
-                for (File file : files) {
-                    String fileName = file.getName();
-                    String uuidPart = fileName.substring(0, fileName.length() - 4);
-                    try {
-                        UUID uuid = UUID.fromString(uuidPart);
-                        long lastModified = file.lastModified();
-                        PlayerCacheEntry entry = playerCache.get(uuid);
-                        if (entry == null || entry.lastModified != lastModified) {
-                            String name = getPlayerNameSync(uuid);
-                            if (name != null) {
-                                playerCache.put(uuid, new PlayerCacheEntry(uuid, name, lastModified));
-                            }
+            if (playerDataFolder.exists()) {
+                File[] files = playerDataFolder.listFiles((dir, name) -> name.endsWith(".dat"));
+                if (files != null) {
+                    for (File file : files) {
+                        String fileName = file.getName();
+                        String uuidPart = fileName.substring(0, fileName.length() - 4);
+                        try {
+                            UUID uuid = UUID.fromString(uuidPart);
+                            long lastModified = file.lastModified();
+                            PlayerCacheEntry entry = playerCache.get(uuid);
+                            if (entry == null || entry.lastModified != lastModified) {
+                                String name = getPlayerNameSync(uuid);
+                                if (name != null) {
+                                    playerCache.put(uuid, new PlayerCacheEntry(uuid, name, lastModified));
+                                }
 
+                            }
+                        } catch (IllegalArgumentException ignored) {
+                            // Ignore files that don't match UUID format
                         }
-                    } catch (IllegalArgumentException ignored) {
-                        // Ignore files that don't match UUID format
                     }
                 }
             }

--- a/src/main/java/world/ultravanilla/cache/data/PlayerCacheEntry.java
+++ b/src/main/java/world/ultravanilla/cache/data/PlayerCacheEntry.java
@@ -1,0 +1,16 @@
+package world.ultravanilla.cache.data;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+public class PlayerCacheEntry implements Serializable {
+    public final UUID uuid;
+    public String name;
+    public long lastModified;
+
+    public PlayerCacheEntry(UUID uuid, String name, long lastModified) {
+        this.uuid = uuid;
+        this.name = name;
+        this.lastModified = lastModified;
+    }
+}


### PR DESCRIPTION
Adds persistent cache for offline player list. Saves to a json file in the plugin folder.

Avoids using NBT calls. Cache name is updated only when a player's dat file has been updated.

Cache is saved on disable.

First run will require the cache to be built, and may lag with large lists.