### PR TITLE
Add PlaceholderAPI support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,12 +8,14 @@ resolvers ++= List(
     "dmulloy2-repo" at "https://repo.dmulloy2.net/nexus/repository/public/",
     "jcenter" at "https://jcenter.bintray.com",
     "m2-dv8tion" at "https://m2.dv8tion.net/releases",
+    "placeholderapi" at "https://repo.extendedclip.com/content/repositories/placeholderapi/"
 )
 libraryDependencies ++= List(
     "io.papermc.paper" % "paper-api" % "1.21.1-R0.1-SNAPSHOT" % Provided,
     "net.luckperms" % "api" % "5.3" % Provided,
     "com.zaxxer" % "HikariCP" % "5.0.1",
-    "net.dv8tion" % "JDA" % "4.3.0_277" exclude("club.minnced", "opus-java")
+    "net.dv8tion" % "JDA" % "4.3.0_277" exclude("club.minnced", "opus-java"),
+    "me.clip" % "placeholderapi" % "2.11.6" % "provided"
 )
 
 scalacOptions += "-target:21"

--- a/plugin.yml
+++ b/plugin.yml
@@ -6,6 +6,8 @@ prefix: UV
 authors: [ Akoot_, lordpipe ]
 description: Official plugin for UltraVanilla Minecraft server
 website: https://ultravanilla.world
+softdepend:
+  - PlaceholderAPI
 depend:
   - LuckPerms
 commands:

--- a/src/main/java/world/ultravanilla/UltraVanilla.scala
+++ b/src/main/java/world/ultravanilla/UltraVanilla.scala
@@ -190,6 +190,12 @@ class UltraVanilla extends JavaPlugin {
 
         staffActionsRecord = new StaffActionsRecord(this)
 
+        // PlaholderAPI
+        if (Bukkit.getPluginManager.getPlugin("PlaceholderAPI") != null) {
+            new world.ultravanilla.papi.Placeholders(this).register()
+            getLogger.info("Linked to PlaceholderAPI.")
+        }
+
         // Add luckperms API
         val luckPermsProvider =
             Bukkit.getServicesManager.getRegistration(classOf[LuckPerms])

--- a/src/main/java/world/ultravanilla/papi/Placeholders.java
+++ b/src/main/java/world/ultravanilla/papi/Placeholders.java
@@ -1,0 +1,30 @@
+package world.ultravanilla.papi;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.entity.Player;
+import world.ultravanilla.UltraVanilla;
+import world.ultravanilla.reference.Users;
+
+public class Placeholders extends PlaceholderExpansion {
+    private final UltraVanilla plugin;
+
+    public Placeholders(UltraVanilla plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override public String getIdentifier() { return "ultravanilla"; }
+    @Override public String getAuthor() { return String.join(", ", plugin.getDescription().getAuthors()); }
+    @Override public String getVersion() { return plugin.getDescription().getVersion(); }
+    @Override public boolean persist() { return true; }
+    @Override public boolean canRegister() { return true; }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String params) {
+        if (player == null) return "";
+        return switch (params.toLowerCase()) {
+            case "afk" -> Users.isAFK(player) ? " (AFK)" : "";
+            case "afk_bool" -> Users.isAFK(player) ? "true" : "false";
+            default -> null;
+        };
+    }
+}


### PR DESCRIPTION
Small code addition that adds PlaceholderAPI to the uv plugin.

Currently implemented placeholders:
- %ultravanilla_afk%
- %ultavanilla_afk_bool%

<img width="476" height="115" alt="image" src="https://github.com/user-attachments/assets/80e6c20f-6a01-4d08-a93d-e6b0285fa877" />
<img width="472" height="181" alt="image" src="https://github.com/user-attachments/assets/c15b7b1c-1aa1-4a52-bad9-517090456f13" />

Shouldn't be hard to add more if needed.