### PR TITLE
restrict tab complete to permitted users

### DIFF
--- a/src/main/java/world/ultravanilla/commands/NickCommand.java
+++ b/src/main/java/world/ultravanilla/commands/NickCommand.java
@@ -66,11 +66,24 @@ public class NickCommand extends UltraCommand implements CommandExecutor, TabExe
         return false;
     }
 
-    @Override
-    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
-        if (args.length == 1 || args.length == 2) {
-            return null;
+   @Override
+public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+    List<String> suggestions = new ArrayList<>();
+
+    if (args.length == 1) {
+        if (sender.hasPermission("ultravanilla.command.nick.others")) {
+            for (Player player : plugin.getServer().getOnlinePlayers()) {
+                if (player.getName().toLowerCase().startsWith(args[0].toLowerCase())) {
+                    suggestions.add(player.getName());
+                }
+            }
         }
-        return new ArrayList<>();
+        return suggestions;
     }
+
+    if (args.length == 2) {
+        return suggestions;
+    }
+
+    return suggestions;
 }

--- a/src/main/java/world/ultravanilla/commands/NickCommand.java
+++ b/src/main/java/world/ultravanilla/commands/NickCommand.java
@@ -66,24 +66,25 @@ public class NickCommand extends UltraCommand implements CommandExecutor, TabExe
         return false;
     }
 
-   @Override
-public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
-    List<String> suggestions = new ArrayList<>();
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        List<String> suggestions = new ArrayList<>();
 
-    if (args.length == 1) {
-        if (sender.hasPermission("ultravanilla.command.nick.others")) {
-            for (Player player : plugin.getServer().getOnlinePlayers()) {
-                if (player.getName().toLowerCase().startsWith(args[0].toLowerCase())) {
-                    suggestions.add(player.getName());
+        if (args.length == 1) {
+            if (sender.hasPermission("ultravanilla.command.nick.others")) {
+                for (Player player : plugin.getServer().getOnlinePlayers()) {
+                    if (player.getName().toLowerCase().startsWith(args[0].toLowerCase())) {
+                        suggestions.add(player.getName());
+                    }
                 }
             }
+            return suggestions;
         }
+
+        if (args.length == 2) {
+            return suggestions;
+        }
+
         return suggestions;
     }
-
-    if (args.length == 2) {
-        return suggestions;
-    }
-
-    return suggestions;
 }


### PR DESCRIPTION
Previously, NickCommand's onTabComplete returned null, which caused Bukkit to auto complete all online player names regardless of permission level.

Now:
- Replaced null return with controlled completions.
- Only users with 'ultravanilla.command.nick.others' get player name suggestions.
- Other users receive an empty list to suppress default completions.

This ensures players without the correct permission cannot tab complete other players' names, which is the expected behavior.