### PR TITLE
fix(commands/seen): default /lastseen and /firstjoined to sender when no args

### DIFF
--- a/src/main/java/world/ultravanilla/commands/SeenCommand.scala
+++ b/src/main/java/world/ultravanilla/commands/SeenCommand.scala
@@ -26,7 +26,16 @@ class SeenCommand(val instance: UltraVanilla) extends UltraCommand(instance) wit
             val zone = UltraVanilla.getPlayerConfig(player.getUniqueId).getString("timezone")
             if (!(zone == null || zone.isEmpty)) timeZone = TimeZone.getTimeZone(zone)
         }
-        val player = plugin.getServer.getOfflinePlayer(args(0))
+
+        val player =
+            if (args.length==0) {
+                if (sender.isInstanceOf[Player]) sender.asInstanceOf[Player]
+                else {
+                    sender.sendMessage(ChatColor.RED + "Usage: /" + command.getName + " <playername>")
+                    return true
+                }
+            } else plugin.getSErver.getOfflinePlayer(args(0))
+        
         if (!player.hasPlayedBefore) {
             sender.sendMessage(Palette.NOUN + player.getName + SeenCommand.COLOR + " has not played here before.")
             return true

--- a/src/main/java/world/ultravanilla/commands/SeenCommand.scala
+++ b/src/main/java/world/ultravanilla/commands/SeenCommand.scala
@@ -33,7 +33,7 @@ class SeenCommand(val instance: UltraVanilla) extends UltraCommand(instance) wit
                     sender.sendMessage(ChatColor.RED + "Usage: /" + command.getName + " <playername>")
                     return true
                 }
-            } else plugin.getSErver.getOfflinePlayer(args(0))
+            } else plugin.getServer.getOfflinePlayer(args(0))
         
         if (!player.hasPlayedBefore) {
             sender.sendMessage(Palette.NOUN + player.getName + SeenCommand.COLOR + " has not played here before.")

--- a/src/main/java/world/ultravanilla/commands/SeenCommand.scala
+++ b/src/main/java/world/ultravanilla/commands/SeenCommand.scala
@@ -26,7 +26,6 @@ class SeenCommand(val instance: UltraVanilla) extends UltraCommand(instance) wit
             val zone = UltraVanilla.getPlayerConfig(player.getUniqueId).getString("timezone")
             if (!(zone == null || zone.isEmpty)) timeZone = TimeZone.getTimeZone(zone)
         }
-
         val player =
             if (args.length==0) {
                 if (sender.isInstanceOf[Player]) sender.asInstanceOf[Player]


### PR DESCRIPTION
Previously, running /lastseen or /firstjoined with no arguments caused an error because the command expected a player name.

Now:
- If a player runs the command with no arguments, it defaults to themself.
- If a non player (e.g. console) runs it without arguments, a proper usage message like "/lastseen <playername>" is shown instead.

This improves usability and prevents null player errors.
