### PR TITLE
Add Sprite and Emoji Shortcode Support to Chat System

### DIFF
--- a/src/main/java/world/ultravanilla/emojis.json
+++ b/src/main/java/world/ultravanilla/emojis.json
@@ -1,0 +1,3 @@
+{
+  "wink": { "type": "head", "uuid": "81faf4e7-33e6-4cfd-bb15-21268d8def8b" },
+}


### PR DESCRIPTION
This PR adds full support for Mojang’s new sprite based text components in the UltraVanilla chat system.
Players can now type things like `:diamond_sword:` or custom defined shortcodes such as `:wink:` directly in chat, which will automatically render as in-game sprites (items or player-head icons).