### PR TITLE
Fix off by 1 error in getRandomString()

### DIFF
--- a/src/main/java/world/ultravanilla/UltraVanilla.scala
+++ b/src/main/java/world/ultravanilla/UltraVanilla.scala
@@ -103,7 +103,7 @@ class UltraVanilla extends JavaPlugin {
     @varargs
     def getRandomString(key: String, format: String*) = {
         val list = getConfig.getStringList("strings." + key)
-        var message = list.get(random.nextInt(list.size - 1))
+        var message = list.get(random.nextInt(list.size))
         var i = 0
         while ({
             i < format.length


### PR DESCRIPTION
Test show last entry in suicide-message is now used, and suicide-messages with only 1 entry doesn't give an error message anymore