### PR TITLE
Fix lag spikes from /mcolor

### DIFF
--- a/src/main/java/world/ultravanilla/commands/McolorCommand.java
+++ b/src/main/java/world/ultravanilla/commands/McolorCommand.java
@@ -8,6 +8,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 import world.ultravanilla.UltraVanilla;
+import world.ultravanilla.cache.data.PlayerCacheEntry;
 import world.ultravanilla.reference.LegacyColors;
 
 import java.util.ArrayList;
@@ -66,11 +67,10 @@ public class McolorCommand extends UltraCommand implements CommandExecutor, TabE
     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
         List<String> suggestions = new ArrayList<>();
         if (args.length == 1) {
-            for (OfflinePlayer offlinePlayer : plugin.getServer().getOfflinePlayers()) {
-                suggestions.add(offlinePlayer.getName());
-                suggestions.add("-disable");
-                suggestions.add("-enable");
-            }
+            suggestions.add("-disable");
+            suggestions.add("-enable");
+            suggestions.addAll(plugin.offlineAutocompleteList());
+            
         } else if (args.length == 2) {
             OfflinePlayer player = plugin.getServer().getOfflinePlayer(args[0]);
 


### PR DESCRIPTION
autotab on /mcolor didn't use the offlineAutocompleteList() like /lastseen, so the patch is bypassed. this now uses the PlayCacheManager to stop lag spikes by autotab